### PR TITLE
Variable fixes

### DIFF
--- a/files/clim
+++ b/files/clim
@@ -37,11 +37,11 @@ COMMANDS
                                          e.x.: "clim service neutron restart"
   service list                         : list all services
   setup_bashrc	                       : crates a .bashrc file and setup variables which can be used as a shortcut for jumping in the correct directory:
-                                          - $def=~/openstack/my_cloud/definition
-                                          - $data=~/openstack/my_cloud/definition/data
-                                          - $scratch=~/scratch/ansible/next/ardana/ansible
-					  - $config=~/openstack/my_cloud/config
-                                            to jump into the DATA directory of the input model, just run "cd $data"
+                                          - \$def=~/openstack/my_cloud/definition
+                                          - \$data=~/openstack/my_cloud/definition/data
+                                          - \$scratch=~/scratch/ansible/next/ardana/ansible
+					  - \$config=~/openstack/my_cloud/config
+                                            to jump into the DATA directory of the input model, just run "cd \$data"
 
 EOF
      exit 0

--- a/files/clim
+++ b/files/clim
@@ -7,7 +7,7 @@ verbose=0
 notify=0
 
 #Set default varables
-ARDANA_USER="ardana"
+[[ -z ${ARDANA_USER+x} ]] && ARDANA_USER="ardana"
 
 # Check if executed as ARDANA_USER, if not exit script
 if [[ "$(whoami)" != "$ARDANA_USER" ]]; then


### PR DESCRIPTION
Added a check to see if ARDANA_USER variable is already set before setting it to default
This makes it possible to set the ARDANA_USER as an export or run clim with
`$ ARDANA_USER=<username> clim -h`
for debugging purposes

I also added esc character to the variable descriptions in help section, so it actually prints the name of the variable instead of the value of the variable
